### PR TITLE
feat: add mdBook documentation website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ devenv.local.nix
 
 # pre-commit
 .pre-commit-config.yaml
+/docs/book

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,17 @@
+[book]
+title = "Wasm Solana Book"
+authors = ["pina-rs contributors"]
+language = "en"
+src = "src"
+description = "The wasm compatible alternative Solana client: RPC, pubsub, wallets and testing utilities for browsers and Rust."
+
+[build]
+build-dir = "book"
+create-missing = false
+
+[output.html]
+default-theme = "light"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/pina-rs/wasm_solana"
+edit-url-template = "https://github.com/pina-rs/wasm_solana/edit/main/docs/{path}"
+site-url = "/wasm_solana/"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,15 @@
+# Summary
+
+- [Introduction](./index.md)
+- [Why Wasm Solana](./why-wasm-solana.md)
+- [Getting Started](./getting-started.md)
+- [Crates](./crates.md)
+- [The RPC Client](./rpc-client.md)
+- [Pubsub and Streams](./pubsub.md)
+- [Providers](./providers.md)
+- [Wallets](./wallets.md)
+- [The Wasm Forks](./forks.md)
+- [Testing](./testing.md)
+- [Security](./security.md)
+- [Development Workflow](./development-workflow.md)
+- [CI and Releases](./ci-and-releases.md)

--- a/docs/src/ci-and-releases.md
+++ b/docs/src/ci-and-releases.md
@@ -1,0 +1,62 @@
+# CI and Releases
+
+## CI
+
+Every pull request runs (`.github/workflows/ci.yml`):
+
+| Job        | What it does                                                       |
+| ---------- | ------------------------------------------------------------------ |
+| `lint`     | clippy + dprint format check.                                      |
+| `security` | cargo-audit, cargo-deny, zizmor.                                   |
+| `test`     | SSR suites, doc tests, streams (live validator) and browser tests. |
+| `coverage` | llvm-cov report uploaded to Codecov.                               |
+| `build`    | locked build for native and `wasm32-unknown-unknown`.              |
+
+All actions are pinned by SHA, checkouts drop credentials, and the workflow runs with `contents: read` only.
+
+## Release flow with MonoChange
+
+Releases are planned by [MonoChange](https://github.com/pina-rs/monochange):
+
+1. **Create a changeset** (`release:change` devenv script or a hand-written `.changeset/*.md`):
+
+   ```markdown
+   ---
+   wasm_client_solana: minor
+   ---
+
+   # Add block subscription filters
+
+   ...
+   ```
+
+   The front matter lists packages and their change type; the body becomes the changelog entry.
+
+2. **Release PR** — when changesets land on `main`, the `release-pr` workflow runs `monochange run release`, which computes versions, updates manifests and `Cargo.lock`, refreshes `changelog.md`, and opens the `monochange/release/*` pull request.
+
+3. **Publish** — merging the release PR tags the release, creates the draft GitHub release and dispatches the `publish` workflow, which publishes every package in dependency order using crates.io **trusted publishing** (OIDC, `environment: publisher`). No registry tokens are stored in the repository.
+
+All nine publishable crates (five workspace crates plus four forks) version together as a single release group: the forks move in lockstep with the client so the wasm stack never mixes Agave families.
+
+## Publishing locally
+
+If CI publishing fails or you need to publish from a machine with credentials:
+
+```bash
+# prepare versions, changelog and lockfile, then commit locally
+release:local
+
+# publish from the local release commit with local cargo credentials
+publish:local
+```
+
+## Versioning rules
+
+| Changeset type       | Version effect (pre-1.0) |
+| -------------------- | ------------------------ |
+| `feat`               | patch bump               |
+| `fix`                | patch bump               |
+| `breaking` / `major` | minor bump (0.5 → 0.6)   |
+| `docs` / `none`      | no release by itself     |
+
+MonoChange applies the standard pre-1.0 bump shifting: breaking changes bump the minor component until the crates reach 1.0.

--- a/docs/src/crates.md
+++ b/docs/src/crates.md
@@ -1,0 +1,60 @@
+# Crates
+
+## Workspace layout
+
+```
+wasm_solana/
+├── crates/
+│   ├── wasm_client_solana/    # the RPC + pubsub client (this is the headline crate)
+│   ├── memory_wallet/         # wallet-standard in-memory wallet
+│   ├── test_utils_solana/     # validator + ProgramTest utilities
+│   ├── test_utils_keypairs/   # fixed keypairs for tests
+│   └── test_utils_insta/      # insta snapshot redactions
+└── forks/
+    ├── solana-account-decoder-client-types-wasm/
+    ├── solana-account-decoder-wasm/
+    ├── solana-transaction-status-client-types-wasm/
+    └── solana-transaction-status-wasm/
+```
+
+## `wasm_client_solana`
+
+The wasm-compatible Solana client.
+
+- `SolanaRpcClient` — the entry point; wraps the provider chosen by your feature flags.
+- 50+ typed RPC methods under `methods/`, each with `Request`/`Response` structs that mirror the JSON-RPC spec.
+- Pubsub subscriptions returning `Subscription<T>` streams.
+- `providers/` — `HttpProvider` (reqwest / ssr) and `WebSocketProvider` (browser / js).
+- Re-exports the forked decoding crates under `solana_account_decoder*` and `solana_transaction_status*` so consumers have one import path.
+
+### The two transports
+
+|              | `js` (wasm)                   | `ssr` (native)              |
+| ------------ | ----------------------------- | --------------------------- |
+| HTTP         | browser `fetch` via gloo-net  | `reqwest`                   |
+| Pubsub       | browser `WebSocket` (web-sys) | `reqwest-websocket` + tokio |
+| Runtime deps | none (promises)               | tokio                       |
+
+## `memory_wallet`
+
+A `wallet_standard`-compliant in-memory wallet. It holds keypairs, signs messages/transactions, can sign _and_ send through the connected `SolanaRpcClient`, and implements the full Solana Wallet Standard feature set. It is designed for tests and prototyping, but is a complete wallet implementation.
+
+## `test_utils_solana`
+
+Boots local Solana environments for integration tests:
+
+- `TestValidatorRunner` — starts a real `solana-test-validator` (agave), wires the faucet, and yields an RPC + websocket URL pair.
+- `ProgramTestExtension` — adds programs and accounts to a `solana-program-test` environment with less boilerplate.
+- Streams helpers (`log_stream_subscription`, `account_stream_subscription`) for exercising pubsub against a live validator.
+
+## `test_utils_keypairs`
+
+Deterministic, pre-defined keypairs (`get_admin_keypair`, `get_wallet_keypair`, ...) so tests reference stable addresses instead of regenerating them.
+
+## `test_utils_insta`
+
+Snapshot helpers for `insta`: redact dynamic values (signatures, slots, timestamps) so RPC snapshots stay deterministic across runs.
+
+## The `solana-*-wasm` forks
+
+See [The Wasm Forks](./forks.md).

--- a/docs/src/development-workflow.md
+++ b/docs/src/development-workflow.md
@@ -1,0 +1,40 @@
+# Development Workflow
+
+The repository uses [devenv](https://devenv.sh) for a hermetic environment. `direnv` loads it automatically.
+
+## Environment
+
+```bash
+devenv shell   # or: direnv allow
+```
+
+Provided by the environment: the pinned Rust toolchain (from `rust-toolchain.toml`), agave (validator binaries) and monochange from `ifiokjr/nixpkgs`, mdbook, chromedriver, wasm-bindgen tooling, and all lint/security tools (cargo-deny, cargo-audit, zizmor, gitleaks).
+
+## Daily commands
+
+| Command                           | Description                                          |
+| --------------------------------- | ---------------------------------------------------- |
+| `build:all`                       | Build all crates with all features.                  |
+| `test:all`                        | Run every suite (SSR, docs, streams, browser tests). |
+| `test:validator`                  | Start a local validator and run the browser tests.   |
+| `coverage:all`                    | llvm-cov coverage across the suites.                 |
+| `lint:all`                        | clippy + dprint format check.                        |
+| `fix:all`                         | Apply clippy and dprint fixes.                       |
+| `security:all`                    | cargo-deny + cargo-audit + zizmor.                   |
+| `update:deps`                     | `cargo update` + `devenv update`.                    |
+| `build:docs`                      | Build this book.                                     |
+| `validator:bg` / `validator:kill` | Manage the local validator.                          |
+
+## Formatting
+
+`dprint` formats everything — Rust via rustfmt nightly, TOML, Markdown, Nix and shell scripts. The pre-commit hook formats changed files; `lint:format` enforces it in CI.
+
+## Git hooks
+
+The devenv git-hooks integration installs gitleaks secret scanning, dprint formatting and nixfmt for Nix files.
+
+## Conventions
+
+- Branch names use Conventional Commit prefixes: `feat/`, `fix/`, `build/`, `ci/`, `docs/`, `chore/`, `test/`.
+- Work happens on feature branches with pull requests; CI must pass before merge.
+- Commits follow Conventional Commits; release automation derives versions from changesets (see [CI and Releases](./ci-and-releases.md)).

--- a/docs/src/forks.md
+++ b/docs/src/forks.md
@@ -1,0 +1,30 @@
+# The Wasm Forks
+
+Four crates under `forks/` are maintained forks of the official Solana decoder crates. They exist because the upstream versions cannot compile on `wasm32-unknown-unknown`.
+
+| Fork                                          | Upstream                                 |
+| --------------------------------------------- | ---------------------------------------- |
+| `solana-account-decoder-client-types-wasm`    | `solana-account-decoder-client-types`    |
+| `solana-account-decoder-wasm`                 | `solana-account-decoder`                 |
+| `solana-transaction-status-client-types-wasm` | `solana-transaction-status-client-types` |
+| `solana-transaction-status-wasm`              | `solana-transaction-status`              |
+
+## What the forks change
+
+1. **Dependency pruning.** Native-only transitive dependencies (tokio-era crates, native C `zstd` bindings in optional positions) are removed or feature-gated so the crates compile for wasm.
+2. **Optional zstd.** Upstream made `zstd` a hard dependency of `solana-account-decoder`; the fork restores it as an optional feature with a plain-base64 fallback, because `zstd-sys` cannot build for wasm32-unknown-unknown. Enable the `zstd` feature on native targets.
+3. **Ergonomic enhancements.** `UiAccount` gains `serde_as`/`skip_serializing_none` attributes, a `TypedBuilder`, and a `Pubkey`-typed `owner` (still serialized as its base58 string). `UiTokenAmount` implements `Eq` so downstream response types can derive `Eq`.
+4. **Upstream parity helpers.** `UiAccount::to_account` / `to_account_shared_data` follow the current upstream API.
+
+Everything else — wire formats, field names, semantics — is byte-for-byte upstream.
+
+## Re-syncing on an Agave upgrade
+
+When the workspace bumps to a new Agave family, the forks are regenerated from the matching upstream sources:
+
+1. Copy the upstream `src/` over each fork.
+2. Re-apply the deltas above (dependency renames to the `-wasm` client types, the builder/`Eq`/zstd gating).
+3. Run `dprint fmt` and compile for both native and wasm targets.
+4. The RPC response snapshot tests in `wasm_client_solana` pin the wire format — they fail loudly if the fork drifted from the real RPC.
+
+The `agave-unstable-api` feature is enabled on the upstream crates that gate themselves behind it, and the client-types forks compile unconditionally (they are published wasm crates).

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,0 +1,98 @@
+# Getting Started
+
+## Installing
+
+```toml
+[dependencies]
+wasm_client_solana = "0.10"
+memory_wallet = "0.2" # optional: wallet-standard signing (great for tests)
+```
+
+### Feature flags of `wasm_client_solana`
+
+| Feature          | Description                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| `js` _(wasm)_    | Browser transport: `fetch` for HTTP and the `WebSocket` API for pubsub. No tokio.  |
+| `ssr` _(native)_ | Server transport: reqwest HTTP and reqwest-websocket, for desktop/server binaries. |
+| `zstd`           | Server-side zstd support for validator snapshots (pulls native C zstd).            |
+
+```toml
+# Browser (wasm32) target
+wasm_client_solana = { version = "0.10", features = ["js"] }
+# Native target
+wasm_client_solana = { version = "0.10", features = ["ssr"] }
+```
+
+## getrandom on wasm32-unknown-unknown
+
+`getrandom` 0.3+ needs an explicit backend on `wasm32-unknown-unknown`. This repository ships the wiring; copy it if your app generates randomness:
+
+```toml
+# .cargo/config.toml
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
+```
+
+```toml
+# crates/*/Cargo.toml
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
+```
+
+## Quickstart: read a balance
+
+```rust,ignore
+use wasm_client_solana::SolanaRpcClient;
+use solana_pubkey::Pubkey;
+
+let client = SolanaRpcClient::new("https://api.devnet.solana.com");
+let pubkey = "So11111111111111111111111111111111111111112".parse()?;
+
+let response = client.get_balance(&pubkey).await?;
+println!("lamports: {}", response.value);
+```
+
+`SolanaRpcClient` is the one constructor for every environment — it selects the `HttpProvider` for `ssr` builds and the browser transport for wasm builds behind the same API.
+
+## Quickstart: sign and send with a wallet
+
+```rust,ignore
+use memory_wallet::MemoryWallet;
+use wasm_client_solana::SolanaRpcClient;
+use test_utils_keypairs::get_wallet_keypair;
+
+let client = SolanaRpcClient::new("https://api.devnet.solana.com");
+let mut wallet = MemoryWallet::new(client, &[get_wallet_keypair()]);
+
+// Sign through the Wallet Standard traits:
+let signed = wallet
+    .sign_message_async(b"hello solana")
+    .await?;
+```
+
+`MemoryWallet` also implements `WalletSolanaSignTransaction` and `WalletSolanaSignAndSendTransaction`, so transaction flows go through the same traits (see [Wallets](./wallets.md)).
+
+## Quickstart: pubsub
+
+```rust,ignore
+use wasm_client_solana::SolanaRpcClient;
+
+let client = SolanaRpcClient::new("wss://api.devnet.solana.com");
+let mut stream = client.account_notifications(&pubkey).await?;
+
+while let Some(notification) = stream.next().await {
+    log::info!("account changed: {notification:?}");
+}
+```
+
+See [Pubsub and Streams](./pubsub.md) for the full subscription model.
+
+## Toolchain
+
+The workspace pins the latest stable Rust in `rust-toolchain.toml` and targets `wasm32-unknown-unknown` + `wasm32-wasip1`. Building the wasm target:
+
+```bash
+cargo build -p wasm_client_solana --target wasm32-unknown-unknown -F js
+```
+
+For `wasm-bindgen` test runs the devenv environment provides `wasm-bindgen-cli`, chromedriver and a local validator — see [Testing](./testing.md).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,43 @@
+# Wasm Solana
+
+`wasm_solana` is the **WebAssembly-compatible alternative to the official Solana client**. The default `solana-client` crate depends on tokio and native networking and cannot run in a browser; this workspace rebuilds the parts of the Solana SDK that apps actually need so the same Rust code can run:
+
+- **in the browser** as WASM (`wasm32-unknown-unknown`),
+- **on the server** with the same code (the `ssr` feature),
+- **against a test validator** with first-class testing utilities.
+
+## What's inside
+
+| Crate                                                                 | Description                                                                 |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [`wasm_client_solana`](https://crates.io/crates/wasm_client_solana)   | A wasm compatible Solana RPC and pubsub client with 50+ typed methods.      |
+| [`memory_wallet`](https://crates.io/crates/memory_wallet)             | A memory based Wallet Standard implementation, primarily for testing.       |
+| [`test_utils_solana`](https://crates.io/crates/test_utils_solana)     | Test validator and `ProgramTest` utilities.                                 |
+| [`test_utils_keypairs`](https://crates.io/crates/test_utils_keypairs) | Pre-defined keypairs for reproducible tests.                                |
+| [`test_utils_insta`](https://crates.io/crates/test_utils_insta)       | Snapshot-test redactions for dynamic values like signatures.                |
+| `solana-*-wasm` (forks)                                               | Wasm-compatible forks of the account decoder and transaction status crates. |
+
+## What you get in this book
+
+- The reasoning behind a wasm-native client and how it compares with `solana-client` ([Why Wasm Solana](./why-wasm-solana.md)).
+- Setup and quickstarts for browsers and SSR ([Getting Started](./getting-started.md)).
+- The RPC client, its typed requests/responses and the provider model.
+- Pubsub subscriptions and the streams utilities.
+- Wallet integration through the Wallet Standard.
+- How the `solana-*-wasm` forks work and when they need re-syncing.
+- Testing, security, development workflow, and the release process.
+
+## Quick taste
+
+```rust,ignore
+use wasm_client_solana::SolanaRpcClient;
+use solana_pubkey::Pubkey;
+
+let client = SolanaRpcClient::new("https://api.devnet.solana.com");
+let pubkey = "So11111111111111111111111111111111111111112".parse()?;
+
+let balance = client.get_balance(&pubkey).await?;
+println!("{balance} lamports");
+```
+
+The same code compiles for `wasm32-unknown-unknown` — no tokio, no native sockets.

--- a/docs/src/providers.md
+++ b/docs/src/providers.md
@@ -1,0 +1,36 @@
+# Providers
+
+The client never performs I/O itself — it delegates to a **provider**. This is the seam that makes one codebase work on native and wasm.
+
+## `RpcProvider`
+
+```rust,ignore
+#[async_trait(?Send)]
+pub trait RpcProvider {
+	async fn send(&self, request: &str) -> Result<String, ClientError>;
+}
+```
+
+`HttpProvider` implements it twice, behind feature flags:
+
+- **`js`**: gloo-net's `fetch` — runs on browser promises, no runtime required.
+- **`ssr`**: `reqwest` with JSON bodies; supports the `zstd` feature for compressed validator payloads.
+
+## `WebSocketProvider`
+
+The pubsub counterpart. It manages connection lifecycle, subscription bookkeeping (`Subscription<T>`, `Unsubscription`), and reconnection semantics. The `js` implementation drives web-sys `WebSocket` events; the `ssr` implementation drives `reqwest-websocket`.
+
+## Choosing at compile time
+
+You never instantiate providers directly. `SolanaRpcClient::new(url)` builds the right one from your feature flags:
+
+| Features        | Transport                        |
+| --------------- | -------------------------------- |
+| none (`wasm32`) | js (browser)                     |
+| `js`            | js (explicit)                    |
+| `ssr`           | reqwest                          |
+| `ssr` + `js`    | ssr wins on native; js on wasm32 |
+
+## Custom providers
+
+Implement `RpcProvider` (and the websocket traits) to route RPC through your own transport — a proxy, a mock server, or an in-memory recorder for tests. The client and all typed methods work unchanged against any provider, which is exactly how `memory_wallet` plugs a test client into wallet-standard signing.

--- a/docs/src/pubsub.md
+++ b/docs/src/pubsub.md
@@ -1,0 +1,45 @@
+# Pubsub and Streams
+
+## Subscriptions
+
+The client exposes typed subscriptions for every pubsub method: `account_notifications`, `program_notifications`, `logs_notifications`, `slot_notifications`, `signature_notifications`, `block_notifications`, `vote_notifications` and friends.
+
+```rust,ignore
+use wasm_client_solana::SolanaRpcClient;
+
+let client = SolanaRpcClient::new("wss://api.devnet.solana.com");
+let mut logs = client.logs_notifications(LogsFilter::All).await?;
+
+while let Some(notification) = logs.next().await {
+    // typed notification values
+}
+```
+
+Each call returns a `Subscription<T>`: a fused stream that owns the websocket connection, resolves the first `subscription` id from the server, and yields typed notifications. Dropping the subscription unsubscribes.
+
+## The provider split
+
+`WebSocketProvider` has two implementations selected by feature flags:
+
+- **`js`** — the browser `WebSocket` API through web-sys; notifications arrive as `web_sys::MessageEvent` and are converted with the `ToWebSocketValue` trait.
+- **`ssr`** — `reqwest-websocket` over tokio, for native binaries that still want pubsub.
+
+Both speak the same JSON-RPC notification protocol, so app code is transport agnostic.
+
+## Streams utilities
+
+`test_utils_solana` provides higher-level stream helpers for integration tests against a live validator:
+
+```rust,ignore
+use test_utils_solana::account_stream_subscription;
+use test_utils_solana::log_stream_subscription;
+```
+
+- `log_stream_subscription` — subscribe to program logs and collect them until a condition matches (used to assert on-chain events).
+- `account_stream_subscription` — watch account updates until a predicate fires.
+
+These helpers make pubsub deterministic in tests: await the event instead of sleeping.
+
+## Timeouts
+
+Wasm browser sockets have no tokio to police them; `WASM_BINDGEN_TEST_TIMEOUT` governs test runs and the subscription streams surface connection failures as `ClientWebSocketError`. For native targets the provider relies on reqwest's own timeouts.

--- a/docs/src/rpc-client.md
+++ b/docs/src/rpc-client.md
@@ -1,0 +1,53 @@
+# The RPC Client
+
+## Constructor
+
+```rust,ignore
+use wasm_client_solana::SolanaRpcClient;
+
+let client = SolanaRpcClient::new("https://api.devnet.solana.com");
+```
+
+- On **native** (`ssr`) targets the URL is an `http(s)://` endpoint.
+- On **wasm** (`js`) targets pass an `http(s)://` URL for RPC; pubsub takes the `wss://` variant.
+
+The client is cheap to clone and methods take `&self`.
+
+## Typed methods
+
+Every RPC method lives in its own module under `methods/` with a `Get<...>Request` struct and a matching response type. The client methods are thin wrappers:
+
+```rust,ignore
+// request + response are public types, so you can also send them manually
+let request = GetBalanceRequest::new_with_config(pubkey, CommitmentConfig::confirmed());
+let response: ClientResponse<GetBalanceResponse> = client.send(request).await?;
+```
+
+`ClientResponse<T>` carries `id`, `jsonrpc` and `result` — the raw JSON-RPC envelope — so nothing is hidden from you.
+
+Coverage spans the full read surface of the JSON-RPC spec: accounts, blocks, epochs, inflation, stakes, token accounts, transactions, plus write methods (`send_transaction`, `request_airdrop`, `simulate_transaction`) and helper checks (`is_blockhash_valid`, `minimum_ledger_slot`).
+
+## Commitments
+
+Every method has a `*_with_config` variant accepting `CommitmentConfig`, and config types (`RpcBlockConfig`, ...) expose the standard options (`encoding`, `data_slice`, filters). Encodings map onto `UiAccountEncoding` from the forked decoder crates, including `base64+zstd` on native targets.
+
+## Errors
+
+RPC failures surface as `ClientError` with structured contents (`RpcError` with code + message), and Solana transaction errors are typed through `solana_transaction_error` — see `errors.rs` for the full hierarchy. The forked client-types also preserve `OptionSerializer<T>` for fields the RPC may omit, null out, or skip for backwards compatibility.
+
+## Re-exports
+
+The client re-exports the wasm decoder crates under their familiar names:
+
+```rust,ignore
+pub use solana_account_decoder_client_types_wasm as solana_account_decoder_client_types;
+pub use solana_account_decoder_wasm as solana_account_decoder;
+pub use solana_transaction_status_client_types_wasm as solana_transaction_status_client_types;
+pub use solana_transaction_status_wasm as solana_transaction_status;
+```
+
+This gives consumers a single import path for parsed accounts, transaction statuses and their types, regardless of which forked crate actually hosts them.
+
+## Versioning
+
+The crate versions track the Agave family it targets. The workspace dependency table pins each `solana-*` crate to the range the stable Agave train publishes (see the workspace `Cargo.toml`), so a wasm client compiled against Agave 4.2.x talks to validators of the same family without type drift.

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -1,0 +1,34 @@
+# Security
+
+This workspace is published to crates.io and is intended as client infrastructure, so supply-chain security is treated as a CI gate.
+
+## Dependency policy
+
+`deny.toml` (cargo-deny) enforces:
+
+- **Licenses** — an explicit allow-list. Notably `LGPL-3.0-or-later` is allowed for `nacl`, which implements the Wallet Standard's experimental encryption scheme. The workspace crates themselves are `Unlicense` (public domain).
+- **Bans** — wildcard dependencies are denied outright; duplicate crate versions are surfaced as warnings (the Agave family legitimately ships a few).
+- **Sources** — crates may only come from crates.io; git sources must be explicitly allow-listed.
+
+## Advisory scanning
+
+`security:audit` checks `Cargo.lock` against RustSec on every CI run.
+
+## Workflow hardening
+
+`security:zizmor` audits all GitHub Actions workflows with a zero-findings policy (`.github/zizmor.yml`):
+
+- every action pinned by commit SHA,
+- `persist-credentials: false` on every checkout,
+- workflow-level permissions limited to `contents: read`,
+- Dependabot updates behind a 7-day cooldown.
+
+## Secret scanning
+
+The pre-commit hook runs `gitleaks protect --staged`. CI publishing uses trusted publishing (crates.io OIDC) rather than stored tokens — see [CI and Releases](./ci-and-releases.md).
+
+## Runtime posture
+
+- The client performs read/write JSON-RPC and pubsub only; no key material is ever handled by `wasm_client_solana` itself.
+- Signing is delegated to Wallet Standard wallets; `memory_wallet` holds keypairs in process memory for tests only.
+- The `ssr` transport uses rustls via reqwest (no vendored OpenSSL).

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -1,0 +1,39 @@
+# Testing
+
+## Test suites
+
+| Suite                      | Command                                                               | Needs                    |
+| -------------------------- | --------------------------------------------------------------------- | ------------------------ |
+| `memory_wallet` (ssr)      | `cargo test_memory_wallet_ssr`                                        | nothing                  |
+| `wasm_client_solana` (ssr) | `cargo test_wasm_client_solana_ssr`                                   | nothing (mock transport) |
+| doc tests                  | `cargo test_memory_wallet_docs`, `cargo test_wasm_client_solana_docs` | nothing                  |
+| streams                    | `cargo test_streams`                                                  | a local validator        |
+| wasm (browser)             | `cargo test_wasm`                                                     | validator + chromedriver |
+
+All aliases live in `.cargo/config.toml` and run through `cargo nextest`.
+
+## RPC response snapshots
+
+Every typed method has a `tests::response` snapshot test that deserializes a real RPC JSON payload into the forked response types. These pin the wire format: if a fork drifts from the actual RPC or a type loses a field, the snapshot test fails. This is what makes the fork regeneration process safe.
+
+## Validator-driven tests
+
+`cargo test_streams` boots a real `solana-test-validator` (agave, provisioned through nixpkgs) and exercises pubsub subscriptions end to end — logs and account streams. The validator lifecycle is managed by `test_utils_solana::TestValidatorRunner`, which also wires the faucet.
+
+## Browser tests
+
+`cargo test_wasm` compiles `wasm_client_solana` for `wasm32-unknown-unknown`, runs `wasm-bindgen-test` through chromedriver, and connects to a background validator:
+
+```bash
+test:validator   # starts the validator, runs the browser tests
+```
+
+The devenv environment provides `wasm-bindgen-cli` (version-pinned to match the `wasm-bindgen` crate), chromedriver and `wait-for-them` for port readiness.
+
+## Coverage
+
+```bash
+coverage:all
+```
+
+produces `codecov.json` via `cargo llvm-cov` across the SSR suites and streams; CI uploads it to Codecov.

--- a/docs/src/wallets.md
+++ b/docs/src/wallets.md
@@ -1,0 +1,47 @@
+# Wallets
+
+Signing is modeled through the [Wallet Standard](https://github.com/pina-rs/wallet_standard), the wasm-native Rust implementation used across this ecosystem. `wasm_client_solana` does not sign anything itself; it bridges to wallet implementations through traits.
+
+## The bridge
+
+`wasm_client_solana::extensions` adds wallet-aware methods to its transaction and message types:
+
+```rust,ignore
+// sign a transaction with any wallet-standard Solana wallet
+let signed = unsigned_transaction.sign_with_wallet(&wallet, options).await?;
+
+// or sign and broadcast in one step
+let signature = transaction.sign_and_send_with_wallet(&wallet).await?;
+```
+
+`W: WalletSolanaSignTransaction` and `W: WalletSolanaSignAndSendTransaction` bounds mean any compliant wallet works — `memory_wallet` in tests, an injected browser wallet through `wallet_standard_browser` in production.
+
+## `memory_wallet`
+
+The workspace ships a complete in-memory wallet for tests:
+
+```rust,ignore
+use memory_wallet::MemoryWallet;
+use wasm_client_solana::SolanaRpcClient;
+use test_utils_keypairs::get_wallet_keypair;
+
+let client = SolanaRpcClient::new("https://api.devnet.solana.com");
+let mut wallet = MemoryWallet::new(client, &[get_wallet_keypair()]);
+```
+
+- Signs messages (`sign_message_async`) and transactions (`sign_transaction_async`).
+- `sign_and_send_transaction_async` submits through the wallet's own `SolanaRpcClient`.
+- Holds multiple accounts and exposes the Wallet Standard account/feature model.
+
+Because it lives entirely in memory, tests get deterministic signing without a browser extension or keyring.
+
+## Testing flows end to end
+
+A typical integration test pairs `memory_wallet` with `test_utils_solana`'s validator runner:
+
+1. Boot a validator (`TestValidatorRunner`) or a `ProgramTest` environment.
+2. Point `SolanaRpcClient` at its RPC/websocket URLs.
+3. Build a `MemoryWallet` over the client and the fixed keypairs from `test_utils_keypairs`.
+4. Drive the wallet-standard signing traits and assert on chain state or stream events.
+
+See [Testing](./testing.md) for the full recipe.

--- a/docs/src/why-wasm-solana.md
+++ b/docs/src/why-wasm-solana.md
@@ -1,0 +1,30 @@
+# Why Wasm Solana
+
+## The gap
+
+Rust compiled to WASM is a natural fit for Solana apps: strong types, no GC pauses, tiny binaries, and one language across client and program. But the official [`solana-client`](https://crates.io/crates/solana-client) cannot follow you into the browser:
+
+- It is built on **tokio** and native TCP/WebSocket stacks that don't exist on `wasm32-unknown-unknown`.
+- The RPC **account decoding** crates (`solana-account-decoder`, `solana-transaction-status`) pull native-only transitive dependencies.
+- There is no maintained `wasm` feature flag anywhere in the stack.
+
+So every Rust/WASM Solana app had to hand-roll JSON-RPC calls, re-implement typed responses, and maintain its own pubsub glue.
+
+## The approach
+
+`wasm_solana` fills the gap with three layers:
+
+1. **Forked decoding crates** — `solana-account-decoder-wasm` and `solana-transaction-status-wasm` are maintained forks of the official decoders with native-only dependencies removed (tokio, zstd C bindings, rocksdb-era deps) and wasm-friendly enhancements (typed builders, `Eq` derives, `Pubkey`-typed fields). They stay close to upstream so RPC data formats remain byte-for-byte compatible.
+2. **A client crate** — `wasm_client_solana` implements the full JSON-RPC surface with typed requests and responses, plus pubsub subscriptions, behind a **provider** abstraction: `HttpProvider` (reqwest, native/SSR) and the browser WebSocket stack (`js` feature, web-sys/gloo).
+3. **Wallet + testing crates** — `memory_wallet` implements the Wallet Standard for signing in tests; `test_utils_*` bootstrap validators, keypairs and snapshot redactions.
+
+## Design principles
+
+- **No tokio in the browser.** The `js` feature path uses browser-native promises and websockets; `ssr` unlocks reqwest + tokio for native targets.
+- **Types mirror the RPC.** Requests and responses are one-to-one with the Solana JSON-RPC specification (via the forked client-types crates), so nothing is silently lossy.
+- **The wallet bridge is trait-based.** Signing goes through the Wallet Standard traits, so the same code works with an injected browser wallet or an in-memory test wallet.
+- **Forks stay close to upstream.** The `solana-*-wasm` crates carry the minimum diff needed for wasm: dependency pruning and ergonomic additions. Every Agave upgrade re-syncs them.
+
+## When not to use it
+
+If your app only runs natively (servers, CLIs, desktop), the official `solana-client` is mature and battle-tested. Use `wasm_solana` when the same Rust code must also run in a browser, or when you want the wallet-standard-native signing model.


### PR DESCRIPTION
## Why

The project's only documentation is the crate readme. This workspace is the WASM-compatible alternative to the official Solana client — that story (why the forks exist, how the transports differ, how wallet signing works) deserves a real documentation site, matching the mdBook setup used in the other Rust projects.

## Implementation

- Add `docs/` with an mdBook covering: why wasm_solana exists, getting started for browser (`js`) and server (`ssr`) targets including the getrandom wasm backend wiring, the typed RPC client and its re-exports, pubsub and the stream helpers, the provider model, wallet-standard signing through `memory_wallet`, the maintained `solana-*-wasm` forks and their re-sync procedure, testing, security policy, development workflow and the release flow.
- Add a `docs-pages` workflow building the book and deploying to GitHub Pages (OIDC, `environment: github-pages`) on pushes touching `docs/**`.
- Add `docs:build` / `docs:serve` devenv scripts (mdbook comes from the devenv environment) and gitignore the built book output.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using GLM 5.3 Flash at xhigh thinking._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Agave 4.2 and Wallet Standard 0.6 support.
  * Added support for newer transaction formats, vote data, memo v4, token batch operations, permissioned burns, and additional system instructions.
  * RPC responses now expose transaction indexes and expanded metadata.

* **Bug Fixes**
  * Improved WASM compatibility and removed dependencies that blocked WASM builds.
  * Improved account conversion and compressed-response handling.

* **Documentation**
  * Added comprehensive guidance for setup, RPC usage, wallets, providers, testing, security, and releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->