### PR TITLE
fix: pass the GitHub environment through devenv in release workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,7 @@ jobs:
             --from HEAD \
             --output "$RUNNER_TEMP/publish-readiness.json" \
             --format json
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: publish packages with monochange
         env:
@@ -95,7 +95,7 @@ jobs:
             --all \
             --output "$RUNNER_TEMP/publish-result.json" \
             --format json
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: publish draft release
         env:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -66,7 +66,7 @@ jobs:
           fi
 
           echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: detect pending changesets
         id: pending_changesets
@@ -105,7 +105,7 @@ jobs:
             exit 1
           fi
           printf '%s\n' "$output"
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: skip refresh without changesets
         if: steps.release_record.outputs.is_release_commit != 'true' && steps.pending_changesets.outputs.has_changesets != 'true'
@@ -156,7 +156,7 @@ jobs:
         run: |
           set -euo pipefail
           monochange --log-level=debug step tag-release --from HEAD --push=true --format json | tee /tmp/tag-report.json
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: create draft releases
         env:
@@ -164,7 +164,7 @@ jobs:
         run: |
           set -euo pipefail
           monochange --log-level=debug step publish-release --from-ref="HEAD" --draft --format json
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       # A tag pushed with GITHUB_TOKEN does not trigger another workflow. Use
       # workflow_dispatch explicitly so publish.yml always receives the release.
@@ -194,7 +194,7 @@ jobs:
               --ref main \
               --field "tag=$tag"
           done
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: comment on released issues
         env:
@@ -202,4 +202,4 @@ jobs:
         run: |
           set -euo pipefail
           monochange --log-level=debug step comment-released-issues --from-ref="HEAD" --auto-close-issues
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}


### PR DESCRIPTION
## Why

The `release-pr` workflow failed on `main`: the `detect current release commit` step runs through `devenv shell -c -- bash -e {0}`, and the `-c` form does not forward the step environment, so `GITHUB_OUTPUT` was unbound and the workflow could never open the release PR.

## Implementation

Switch the release workflow steps that read the GitHub environment (`release-pr.yml`, `publish.yml`) to `devenv shell -- bash -e {0}` — the same invocation the `pina` release workflows use, which forwards the environment.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using GLM 5.3 Flash at xhigh thinking._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated publishing and release workflows to ensure release checks, package publishing, tagging, draft release creation, and related notifications run correctly.
  * No user-facing feature or functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->