### PR TITLE
fix: mark the workspace crates as publishable

### DIFF
--- a/crates/memory_wallet/Cargo.toml
+++ b/crates/memory_wallet/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 homepage = { workspace = true }
 keywords = ["solana", "wallet", "web3", "blockchain"]
 license = { workspace = true }
-publish = false
+publish = true
 readme = "readme.md"
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/test_utils_insta/Cargo.toml
+++ b/crates/test_utils_insta/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-publish = false
+publish = true
 readme = "readme.md"
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/test_utils_keypairs/Cargo.toml
+++ b/crates/test_utils_keypairs/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-publish = false
+publish = true
 readme = "readme.md"
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/test_utils_solana/Cargo.toml
+++ b/crates/test_utils_solana/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-publish = false
+publish = true
 readme = "readme.md"
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/wasm_client_solana/Cargo.toml
+++ b/crates/wasm_client_solana/Cargo.toml
@@ -6,7 +6,7 @@ categories = ["wasm", "web-programming"]
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-publish = false
+publish = true
 readme = "readme.md"
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/forks/solana-account-decoder-client-types-wasm/Cargo.toml
+++ b/forks/solana-account-decoder-client-types-wasm/Cargo.toml
@@ -6,7 +6,7 @@ documentation = "https://docs.rs/solana-account-decoder-client-types"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-publish = false
+publish = true
 repository = { workspace = true }
 description = "Core RPC client types for solana-account-decoder"
 

--- a/forks/solana-account-decoder-wasm/Cargo.toml
+++ b/forks/solana-account-decoder-wasm/Cargo.toml
@@ -6,7 +6,7 @@ documentation = "https://docs.rs/solana-account-decoder"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-publish = false
+publish = true
 repository = { workspace = true }
 description = "Solana account decoder"
 

--- a/forks/solana-transaction-status-client-types-wasm/Cargo.toml
+++ b/forks/solana-transaction-status-client-types-wasm/Cargo.toml
@@ -6,7 +6,7 @@ documentation = "https://docs.rs/solana-transaction-status-client-types"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-publish = false
+publish = true
 repository = { workspace = true }
 description = "Core RPC client types for solana-transaction-status"
 

--- a/forks/solana-transaction-status-wasm/Cargo.toml
+++ b/forks/solana-transaction-status-wasm/Cargo.toml
@@ -6,7 +6,7 @@ documentation = "https://docs.rs/solana-transaction-status"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-publish = false
+publish = true
 repository = { workspace = true }
 description = "Solana transaction status types"
 


### PR DESCRIPTION
## Why

All nine crate manifests still carried `publish = false` from the knope era. Monochange reads that as "private" and drops the packages from the release publications, which made the publish step run with an empty package list for the v0.11.0 release (the tag and draft release were created, but no crates were published).

## Implementation

Set `publish = true` on the five workspace crates and the four wasm forks so monochange publishes them.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using GLM 5.3 Flash at xhigh thinking._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enabled publication of several wallet, testing utility, WebAssembly client, and Solana compatibility packages to the package registry.
  - These packages can now be distributed and consumed through the registry when published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->