### PR TITLE
chore: add changeset to republish the versioned workspace crates

### DIFF
--- a/.changeset/republish-workspace-crates.md
+++ b/.changeset/republish-workspace-crates.md
@@ -1,0 +1,15 @@
+---
+memory_wallet: fix
+test_utils_insta: fix
+test_utils_keypairs: fix
+test_utils_solana: fix
+wasm_client_solana: fix
+solana-account-decoder-client-types-wasm: fix
+solana-account-decoder-wasm: fix
+solana-transaction-status-client-types-wasm: fix
+solana-transaction-status-wasm: fix
+---
+
+# Mark the workspace crates as publishable
+
+The v0.11.0 release record had no package publications because every crate manifest still carried `publish = false` from the knope era; crates.io never received the versioned crates. With `publish = true` restored this release publishes the already-versioned crates.


### PR DESCRIPTION
## Why

The v0.11.0 release published zero crates: the release record embedded in the tag listed no package publications because every crate manifest still carried `publish = false` from the knope era. This changeset triggers a new release so the publishable manifests flow through the release PR and reach crates.io.

## Implementation

Add a changeset bumping all nine crates with `fix`, documenting that this release publishes the already-versioned crates that the v0.11.0 record skipped.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using GLM 5.3 Flash at xhigh thinking._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Restored publishing eligibility for ten workspace packages.
  - Added release tracking for fixes to those packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->