### PR TITLE
fix: include dev-dependencies in the cargo publish order

### DIFF
--- a/monochange.toml
+++ b/monochange.toml
@@ -158,7 +158,10 @@ mode = "builtin"
 trusted_publishing = { enabled = true, repository = "pina-rs/wasm_solana", workflow = "publish.yml", environment = "publisher" }
 
 [ecosystems.cargo.publish_order]
-dependency_fields = ["dependencies", "build-dependencies"]
+# dev-dependencies are included because `cargo publish --locked` resolves them
+# during packaging: a workspace dev-dependency that is not on the registry yet
+# fails the publish of the dependent crate.
+dependency_fields = ["dependencies", "build-dependencies", "dev-dependencies"]
 
 [changesets.affected]
 enabled = true


### PR DESCRIPTION
## Why

`memory_wallet` has a dev-dependency on `test_utils_solana`. `cargo publish --locked` resolves dev-dependencies during packaging, so publishing `memory_wallet` before `test_utils_solana` fails with "failed to select a version for the requirement `test_utils_solana = ^0.11.1`". The v0.11.1 publish failed on exactly this.

## Implementation

Add `dev-dependencies` to `[ecosystems.cargo.publish_order].dependency_fields` so monochange publishes workspace crates whose dev-dependencies are still missing from the registry after their dependents.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using GLM 5.3 Flash at xhigh thinking._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Cargo package publishing with locked builds by ensuring workspace development dependencies are resolved during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->