### PR TITLE
chore: add changeset to publish the crates missed by the v0.11.1 release

### DIFF
--- a/.changeset/publish-missed-crates.md
+++ b/.changeset/publish-missed-crates.md
@@ -1,0 +1,15 @@
+---
+memory_wallet: fix
+test_utils_solana: fix
+test_utils_insta: fix
+test_utils_keypairs: fix
+wasm_client_solana: fix
+solana-account-decoder-client-types-wasm: fix
+solana-account-decoder-wasm: fix
+solana-transaction-status-client-types-wasm: fix
+solana-transaction-status-wasm: fix
+---
+
+# Publish the versioned crates that missed the v0.11.1 release
+
+The v0.11.1 publish published the forks and `wasm_client_solana`, but `memory_wallet` failed because `cargo publish --locked` resolves dev-dependencies and `test_utils_solana ^0.11.1` was not on crates.io yet. The publish order now includes dev-dependencies, so this release publishes the remaining crates.


### PR DESCRIPTION
## Why

The v0.11.1 publish published the forks and `wasm_client_solana`, but `memory_wallet` failed because `cargo publish --locked` resolves dev-dependencies and `test_utils_solana ^0.11.1` was not on crates.io yet. The publish order now includes dev-dependencies (previous PR), so this release publishes the remaining crates.

## Implementation

Add a changeset bumping all nine crates with `fix`, documenting that this release publishes the already-versioned crates that the v0.11.1 record skipped.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using GLM 5.3 Flash at xhigh thinking._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Management**
  - Added patch-level release tracking for nine crates that were not included in the v0.11.1 publication.
  - Updated the planned publication sequence to account for development dependencies and ensure the remaining crates are released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->