### PR TITLE
fix: extend the publish timeout for test_utils_solana

### DIFF
--- a/monochange.toml
+++ b/monochange.toml
@@ -107,6 +107,11 @@ type = "cargo"
 path = "forks/solana-transaction-status-wasm"
 type = "cargo"
 
+[package.test_utils_solana.publish.timeout]
+# The publish dry-run compiles the whole validator stack, which takes
+# minutes cold; the 60-second default is a cold-runner timeout, not a hang.
+timeout_seconds = 900
+
 # The workspace crates release as one versioned identity: they share
 # workspace.package.version and move in lockstep.
 [group.core]


### PR DESCRIPTION
## Why

The v0.11.2 publish published 7 of 9 crates; `test_utils_solana` timed out after 60 seconds because the publish dry-run compiles the whole validator stack on a cold runner. The 60-second default is a cold-runner timeout, not a hang.

## Implementation

Add a per-package publish timeout override for `test_utils_solana` (900 seconds), mirroring the same override `pina` uses for its Surfpool test crate.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using GLM 5.3 Flash at xhigh thinking._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the package publishing timeout to 15 minutes, helping accommodate longer validator-stack compilation times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->